### PR TITLE
(feat) share links for social networks

### DIFF
--- a/client/components/ShareCard.jsx
+++ b/client/components/ShareCard.jsx
@@ -82,9 +82,12 @@ var ShareFacebook = React.createClass({
 
 // Currently just a link to Twitter
 var ShareTwitter = React.createClass({
+  getDefaultProps: function () {
+    return {contents: messageDefaults.contents}
+  },
   render: function () {
     return (
-      <a href='https://twitter.com/' target="_blank" className="twitter">
+      <a href={'https://twitter.com/home?status='+this.props.contents} target="_blank" className="twitter">
         <i className="fa fa-twitter"></i>
       </a>
     );

--- a/client/components/ShareCard.jsx
+++ b/client/components/ShareCard.jsx
@@ -59,7 +59,7 @@ var ShareEmail = React.createClass({
   }
 });
 
-// Currently just a link to Google+
+// Shares to Google+. Can only share link, no caption.
 var ShareGoogle = React.createClass({
   getDefaultProps: function () {
     return {url: messageDefaults.url}
@@ -73,18 +73,21 @@ var ShareGoogle = React.createClass({
   }
 });
 
-// Currently just a link to facebook
+// Shares to facebook. Can only share link, no caption.
 var ShareFacebook = React.createClass({
+  getDefaultProps: function () {
+    return {url: messageDefaults.url}
+  },
   render: function () {
     return (
-      <a href='https://www.facebook.com/' target="_blank" className="facebook">
+      <a href={'http://www.facebook.com/sharer/sharer.php?u='+this.props.url} target="_blank" className="facebook">
         <i className="fa fa-facebook"></i>
       </a>
     );
   }
 });
 
-// Currently just a link to Twitter
+// Shares to twitter, no problem.
 var ShareTwitter = React.createClass({
   getDefaultProps: function () {
     return {contents: messageDefaults.contents}
@@ -113,7 +116,7 @@ var ShareCard = React.createClass({
         <ShareSMS contents={this.props.contents} />
         <ShareEmail contents={this.props.contents} subject={this.props.subject}/>
         <ShareGoogle url={this.props.url} />
-        <ShareFacebook contents={this.props.contents} />
+        <ShareFacebook url={this.props.url} />
         <ShareTwitter contents={this.props.contents} />
       </div>
     );

--- a/client/components/ShareCard.jsx
+++ b/client/components/ShareCard.jsx
@@ -60,9 +60,12 @@ var ShareEmail = React.createClass({
 
 // Currently just a link to Google+
 var ShareGoogle = React.createClass({
+  getDefaultProps: function () {
+    return {contents: messageDefaults.contents}
+  },
   render: function () {
     return (
-      <a href='https://plus.google.com/' target="_blank" className="googleplus">
+      <a href={'https://plus.google.com/share?url='+this.props.contents} target="_blank" className="googleplus">
         <i className="fa fa-google-plus"></i>
       </a>
     );

--- a/client/components/ShareCard.jsx
+++ b/client/components/ShareCard.jsx
@@ -1,7 +1,8 @@
 // Default values for contents (body) and subject of messages.
 var messageDefaults = {
   contents: 'Check out Spots! www.spots.com',
-  subject: 'Check out Spots'
+  subject: 'Check out Spots',
+  url: 'http://www.spots.com'
 }
 
 
@@ -61,11 +62,11 @@ var ShareEmail = React.createClass({
 // Currently just a link to Google+
 var ShareGoogle = React.createClass({
   getDefaultProps: function () {
-    return {contents: messageDefaults.contents}
+    return {url: messageDefaults.url}
   },
   render: function () {
     return (
-      <a href={'https://plus.google.com/share?url='+this.props.contents} target="_blank" className="googleplus">
+      <a href={'https://plus.google.com/share?url='+this.props.url} target="_blank" className="googleplus">
         <i className="fa fa-google-plus"></i>
       </a>
     );
@@ -101,7 +102,8 @@ var ShareCard = React.createClass({
   getDefaultProps: function () {
     return {
       contents: messageDefaults.contents,
-      subject: messageDefaults.subject
+      subject: messageDefaults.subject,
+      url: messageDefaults.url
     }
   },
 
@@ -110,7 +112,7 @@ var ShareCard = React.createClass({
       <div className='share-card'>
         <ShareSMS contents={this.props.contents} />
         <ShareEmail contents={this.props.contents} subject={this.props.subject}/>
-        <ShareGoogle contents={this.props.contents} />
+        <ShareGoogle url={this.props.url} />
         <ShareFacebook contents={this.props.contents} />
         <ShareTwitter contents={this.props.contents} />
       </div>


### PR DESCRIPTION
This sets up the logic for Google+, facebook, and twitter links. Google+ and facebook only support sharing a url, you cannot send a message.

Should use Open Graph Protocol to provide meta data for each page that we link. Meta tags will need to be included in SpotView and MapView (maybe also ProfileView).

See:
https://developers.facebook.com/docs/opengraph/getting-started
