### PR TITLE
(fix) Sets proper scale for iOS devices

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,6 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8">
+    
+    <!-- Fixes scaling issues on iOS -->
+    <meta name = "viewport" content = "user-scalable=no, width=device-width">
+
     <title>Spotter</title>
 
     <!-- Material icons -->
@@ -35,7 +39,6 @@
     <script type="text/javascript" src="/dist/src/components/NavBar.js"></script>
     <script type="text/javascript" src="/dist/src/components/ShareCard.js"></script>
     <script type="text/javascript" src="/dist/src/app.js"></script>
-    
+
   </body>
 </html>
-


### PR DESCRIPTION
Pixels measurements were scaling poorly on iOS devices.

BEFORE
![img_1436](https://cloud.githubusercontent.com/assets/15370822/13727591/a75c394c-e8b5-11e5-9175-93a73c17599f.PNG)

AFTER
![img_1437](https://cloud.githubusercontent.com/assets/15370822/13727592/af925484-e8b5-11e5-8ed1-da4fad0e5f19.PNG)
