### PR TITLE
(style) adds temporary form formatting

### DIFF
--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -1,3 +1,6 @@
+// Roboto Font
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
 ::-webkit-scrollbar {
   display: none;
 }
@@ -12,6 +15,10 @@ form {
   input {
     display: block;
   }
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
 }
 
 // Makes circle buttons
@@ -145,6 +152,30 @@ form {
 
     &:hover {
       background-color: lighten(#7de264, 10);
+    }
+  }
+}
+
+
+// Everything from here down can likely be removed when Material-UI is implimented
+form {
+  padding: 20px;
+
+  input {
+    padding: 5px;
+    margin: 5px;
+    font-size: 1.5em;
+    width: calc(100% - 20px);
+  }
+
+  input[type=submit] {
+    margin: 10px;
+    background-color: $primary-color;
+    border: 0px;
+    color: #fff;
+
+    &:hover {
+      background-color: $color-light;
     }
   }
 }


### PR DESCRIPTION
This styling is not final. It should be removed when Material-UI is implemented next week.

![screen shot 2016-03-13 at 9 21 10 am](https://cloud.githubusercontent.com/assets/15370822/13729899/02827fec-e8fd-11e5-97c2-d80740b4b2da.png)
